### PR TITLE
tex-buf.el was renamed to tex.el

### DIFF
--- a/auctex-cluttex.el
+++ b/auctex-cluttex.el
@@ -5,7 +5,7 @@
 ;; Author: Masahiro Nakamura <tsuucat@icloud.com>
 ;; Version: 0.2.0
 ;; URL: https://github.com/tsuu32/auctex-cluttex
-;; Package-Requires: ((emacs "24.4") (auctex "12.2"))
+;; Package-Requires: ((emacs "24.4") (auctex "13.1"))
 ;; Keywords: tex
 
 ;; This program is free software; you can redistribute it and/or modify
@@ -37,7 +37,7 @@
 
 (require 'tex)
 (require 'latex)
-(require 'tex-buf)
+(require 'tex)
 
 (require 'cl-lib)
 


### PR DESCRIPTION
https://git.savannah.gnu.org/cgit/auctex.git/commit/?id=4b1c7015ae77b88832af35510232e1a1b716da3a